### PR TITLE
Disable SIMD for tcc

### DIFF
--- a/stb-image.scm
+++ b/stb-image.scm
@@ -1,4 +1,8 @@
 (foreign-declare "
+#ifdef __TINYC__
+#define STBI_NO_SIMD
+#endif
+
 #define STB_IMAGE_IMPLEMENTATION
 #define STBI_NO_STDIO
 #include \"stb_image.h\"


### PR DESCRIPTION
The egg currently fails to build with tcc as it cannot find emmintrin.h. This file seems to provide SSE2 instructions and only appears to be available with gcc and clang. Therefore I've added code to conditionally disable its inclusion when compiling with tcc.

https://salmonella-linux-x86-64.call-cc.org/master/tcc/linux/x86-64/2021/08/16/salmonella-report/install/stb-image.html